### PR TITLE
Disable integration tests step in CI until they exist

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,17 +85,6 @@ pipeline {
             }
         }
 
-        stage("Integration Tests"){
-            when {
-                expression {
-                    return env.shouldBuild != "false"
-                }
-            }
-            steps {
-                sh './build/run make -j\$(nproc) e2e'
-            }
-        }
-
         stage('Publish Coverage to Codecov') {
             when {
                 expression {


### PR DESCRIPTION
Disables integration tests step while none exists and tests to make sure that CI is configured correctly.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>